### PR TITLE
Extend trace() to work on ops with tf.Variable input

### DIFF
--- a/nvtx_plugins/python/nvtx/plugins/tf/ops.py
+++ b/nvtx_plugins/python/nvtx/plugins/tf/ops.py
@@ -33,11 +33,11 @@ def _maybe_convert_list_to_tensor(inputs):
     inputs_were_processed = False
 
     if isinstance(inputs, (list, tuple)) and \
-        all([isinstance(x, tf.Tensor) for x in inputs]):
+        all([isinstance(x, (tf.Tensor, tf.Variable)) for x in inputs]):
         inputs = tf.stack(inputs, axis=0, name="nvtx_trace_inputs")
         inputs_were_processed = True
 
-    assert isinstance(inputs, tf.Tensor)
+    assert isinstance(inputs, (tf.Tensor, tf.Variable)), "Not a tensor or variable: {}".format(inputs)
 
     return inputs, inputs_were_processed
 


### PR DESCRIPTION
I ran into an assertion when I was trying to apply `nvtx.plugins.tf.ops.trace()` to the Horovod broadcast of a variable (TF 2.4, V1 compatible API). `tf.Variable` mostly behaves like a `tf.Tensor`, but it is not a formal subclass.