### PR TITLE
Add CPU kernel builders

### DIFF
--- a/nvtx_plugins/cc/nvtx_kernels.cc
+++ b/nvtx_plugins/cc/nvtx_kernels.cc
@@ -205,3 +205,24 @@ class NvtxEndOp : public OpKernel {
 
 TF_CALL_NUMBER_TYPES(REGISTER_GPU_KERNEL);
 #undef REGISTER_GPU_KERNEL
+
+#define REGISTER_CPU_KERNEL(type)                                 \
+  REGISTER_KERNEL_BUILDER(Name("NvtxStart")                       \
+                              .Device(DEVICE_CPU)                 \
+                              .HostMemory("message")              \
+                              .HostMemory("domain_name")          \
+                              .HostMemory("marker_id")            \
+                              .HostMemory("domain_handle")        \
+                              .TypeConstraint<type>("T"),         \
+                          NvtxStartOp<type>);                     \
+  REGISTER_KERNEL_BUILDER(Name("NvtxEnd")                         \
+                              .Device(DEVICE_CPU)                 \
+                              .HostMemory("marker_id")            \
+                              .HostMemory("domain_handle")        \
+                              .HostMemory("grad_message")         \
+                              .HostMemory("grad_domain_name")     \
+                              .TypeConstraint<type>("T"),         \
+                          NvtxEndOp<type>);
+
+TF_CALL_NUMBER_TYPES(REGISTER_CPU_KERNEL);
+#undef REGISTER_CPU_KERNEL


### PR DESCRIPTION
Currently, it is not possible to add NVTX tracing to ops that may be executed on CPU rather than GPU. In that case one would run into exceptions like 
`tensorflow.python.framework.errors_impl.InvalidArgumentError: Cannot assign a device for operation .../NvtxStart: Could not satisfy explicit device specification '/device:CPU:0' because no supported kernel for CPU devices is available.`

This can be fixed in a straight-forward manner by registering CPU kernels for `NvtxStart` and `NvtxEnd`. As far as I can tell, NVTX tracing should work fine for non-CUDA code, so this feels generally useful to me.